### PR TITLE
[Windows] Prevent file not found error

### DIFF
--- a/src/utils/dockerCompose.js
+++ b/src/utils/dockerCompose.js
@@ -20,7 +20,7 @@ async function writeComposeFileToHomeDir(compose) {
 
 function createDockerComposeCommand(compose, async = true) {
   return async ({ cmd, msg, options }) => {
-    const command = `docker-compose -f ${compose} ${cmd}`;
+    const command = `docker-compose -f "${compose}" ${cmd}`;
 
     if (async) {
       const spinner = msg && print.spin(msg);


### PR DESCRIPTION
`devctl up` would fail due to the file path being represented as `CUsersJon...`. This wraps the file path in quotes to prevent slashes from being stripped.