### PR TITLE
Fixes for running plugins outside a devctl project

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "get-port": "^5.0.0",
     "gluegun": "^4.1.2",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "node_modules-path": "^2.0.5"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,6 @@
 const { build } = require('gluegun');
+const { resolve } = require('path');
+const node_modules = require('node_modules-path');
 
 /**
  * Create the cli and kick it off
@@ -8,7 +10,7 @@ async function run(argv) {
   const cli = build()
     .brand('devctl')
     .src(__dirname)
-    .plugins('./node_modules', { matching: 'devctl-*', hidden: true })
+    .plugins(node_modules(), { matching: 'devctl-*', hidden: false })
     .help() // provides default for help, h, --help, -h
     .version() // provides default for version, v, --version, -v
     .create();

--- a/src/commands/devctl.js
+++ b/src/commands/devctl.js
@@ -3,7 +3,7 @@ const { resolve } = require('path');
 
 function getCustomCommands(toolbox) {
   const { get, print } = toolbox;
-  const commands = get('commands');
+  const commands = get('commands', []);
 
   print.newline();
   print.info('Custom commands: ');

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -7,9 +7,11 @@ module.exports = {
   run: async toolbox => {
     const { config } = toolbox;
 
+    const services = get(config, 'current.services', []);
+
     const table = [
       ['Service', 'Notes'],
-      ...config.current.services.map(svc => {
+      ...services.map(svc => {
         const service = config.services[svc];
 
         const note = get(service, 'notes', '')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,6 +3251,11 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
+node_modules-path@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/node_modules-path/-/node_modules-path-2.0.5.tgz#477b1e95d2a365976db3a799ba7709fb476edf58"
+  integrity sha512-l5wyQWP56Gct/qpBV9lAJA9Al+WhwF0PTtfzpla8cd0wa735e03fhpV0wyN1MZHFm/yF9+kxPdBXxMVL8S73iQ==
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"


### PR DESCRIPTION
This PR should allow to create and load plugins into devctl even when installed in global.

Changes:  
 - added `node_modules-path` package for searching plugins
    from inside node_modules
 - fixed getCustomCommands to handle situations
    where devctl is run outside a devctl project without throwing a fit
 - fixed status.js to handle situations
    where devctl is run outside a devctl project without throwing a fit

