### PR TITLE
getProjectConfig extensions hijacks `toolbox.config`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@splitmedialabs/devctl",
-  "version": "3.1.0",
+  "name": "@nicodoggie/devctl",
+  "version": "3.1.2",
   "author": "Makara Sok",
-  "description": "Easily start developing in monorepos with docker-compose",
+  "description": "Easily start developing in monorepos with docker-compose, development fork",
   "bin": {
     "devctl": "bin/devctl"
   },
@@ -15,10 +15,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SplitmediaLabsLimited/devctl.git"
+    "url": "git+https://github.com/nicodoggie/devctl.git"
   },
   "bugs": {
-    "url": "https://github.com/SplitmediaLabsLimited/devctl/issues"
+    "url": "https://github.com/nicodoggie/devctl/issues"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nicodoggie/devctl",
-  "version": "3.1.2",
+  "name": "@splitmedialabs/devctl",
+  "version": "3.1.4",
   "author": "Makara Sok",
   "description": "Easily start developing in monorepos with docker-compose, development fork",
   "bin": {

--- a/src/extensions/getProjectConfig.js
+++ b/src/extensions/getProjectConfig.js
@@ -54,6 +54,7 @@ module.exports = async toolbox => {
   const projectConfig = await toolbox.getProjectConfig();
 
   toolbox.config = {
+    ...toolbox.config,
     ...projectConfig,
   };
 


### PR DESCRIPTION
Currently the `getProjectConfig` extension, which fetches devctl monorepo config simple overwrites `toolbox.config` which causes problems with plugins wanting to expose configuration on that same object either by extending it on its own, or by using gluegun's built-in cosmiconfig.

Fix is to destructure the previous contents of `toolbox.config` before it's mutated.