### PR TITLE
getProjectConfig extensions hijacks `toolbox.config`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitmedialabs/devctl",
-  "version": "3.1.0",
+  "version": "3.1.4",
   "author": "Makara Sok",
   "description": "Easily start developing in monorepos with docker-compose",
   "bin": {

--- a/src/extensions/getProjectConfig.js
+++ b/src/extensions/getProjectConfig.js
@@ -54,6 +54,7 @@ module.exports = async toolbox => {
   const projectConfig = await toolbox.getProjectConfig();
 
   toolbox.config = {
+    ...toolbox.config,
     ...projectConfig,
   };
 


### PR DESCRIPTION
Currently the `getProjectConfig` extension, which fetches
devctl monorepo config simple overwrites `toolbox.config`
which causes problems with plugins wanting to expose
configuration on that same object either by extending it on its own,
or by using gluegun's built-in cosmiconfig.

Fix is to destructure the previous contents of `toolbox.config`
before it's mutated.