### PR TITLE
Support latest Docker Compose schema.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bluebird": "^3.7.1",
     "concurrently": "^5.0.2",
     "cosmiconfig": "^6.0.0",
+    "deepmerge": "^4.2.2",
     "dockerode": "^3.0.2",
     "get-port": "^5.0.0",
     "gluegun": "^4.1.2",

--- a/src/commands/compile.js
+++ b/src/commands/compile.js
@@ -1,6 +1,7 @@
 const Promise = require('bluebird');
 const YAML = require('js-yaml');
 const { filesystem } = require('gluegun');
+const deepmerge = require('deepmerge');
 const { stringifyToEnv, parseEnv } = require('../utils/dotenv');
 const resolveService = require('../utils/resolveService');
 
@@ -22,10 +23,7 @@ module.exports = {
       const { compose, dotenv, path } = service;
 
       // compile the final docker-compose
-      finalDockerCompose = {
-        ...finalDockerCompose,
-        ...compose,
-      };
+      finalDockerCompose = deepmerge(finalDockerCompose, compose);
 
       if (!dotenv) {
         return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,6 +1206,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"


### PR DESCRIPTION
This will allow Docker Compose configs to have similar top level keys such as `version` and `services`. e.g.

```
---
# frontend/.devconfig.yaml
version: 3.7
services:
  redis:
    image: redis:latest

---
# backend/.devconfig.yaml
version: 3.7
services:
  mysql:
    image: mysql:5.7

---
# .devctl-docker-compose.yaml
version: 3.7
services:
  redis:
    image: redis:latest
  mysql:
    image: mysql:5.7
```